### PR TITLE
Use NoSafepointVerifier + avoid extra safepoint in `Unsafe_CopySwapMemory0`

### DIFF
--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -421,6 +421,9 @@ UNSAFE_ENTRY(void, Unsafe_CopySwapMemory0(JNIEnv *env, jobject unsafe, jobject s
 
     {
       GuardUnsafeAccess guard(thread);
+      // Transitioning to native state below checks NSV, but doesn't actually do a safepoint poll.
+      // So, this is safe to ignore, as no async exception handshake can actually be installed.
+      PauseNoSafepointVerifier pnsv(&nsv);
       // Transition to native state. Since the source and destination are both in native memory
       // the copy may potentially be very large, and we don't want to disable GC if we can avoid it.
       ThreadToNativeFromVM ttn(thread);

--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -406,14 +406,6 @@ extern "C" {                                                         \
     VM_LEAF_BASE(result_type, header)
 
 
-#define JVM_ENTRY_FROM_LEAF(env, result_type, header)                \
-  { {                                                                \
-    JavaThread* thread=JavaThread::thread_from_jni_environment(env); \
-    ThreadInVMfromNative __tiv(thread);                              \
-    debug_only(VMNativeEntryWrapper __vew;)                          \
-    VM_ENTRY_BASE_FROM_LEAF(result_type, header, thread)
-
-
 #define JVM_END } }
 
 #endif // SHARE_RUNTIME_INTERFACESUPPORT_INLINE_HPP

--- a/test/jdk/java/foreign/TestHandshake.java
+++ b/test/jdk/java/foreign/TestHandshake.java
@@ -33,6 +33,7 @@
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
@@ -48,6 +49,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static org.testng.Assert.*;
 
 public class TestHandshake {
@@ -176,6 +178,30 @@ public class TestHandshake {
         }
     }
 
+    static class SegmentSwappyCopyAccessor extends AbstractSegmentAccessor {
+
+        MemorySegment first, second;
+        ValueLayout sourceLayout, destLayout;
+        long count;
+
+
+        SegmentSwappyCopyAccessor(int id, MemorySegment segment, Arena _unused) {
+            super(id, segment);
+            long split = segment.byteSize() / 2;
+            first = segment.asSlice(0, split);
+            sourceLayout = JAVA_INT.withOrder(ByteOrder.LITTLE_ENDIAN);
+            second = segment.asSlice(split);
+            destLayout = JAVA_INT.withOrder(ByteOrder.BIG_ENDIAN);
+            count = Math.min(first.byteSize() / sourceLayout.byteSize(),
+                second.byteSize() / destLayout.byteSize());
+        }
+
+        @Override
+        public void doAccess() {
+            MemorySegment.copy(first, sourceLayout, 0L, second, destLayout, 0L, count);
+        }
+    }
+
     static class SegmentFillAccessor extends AbstractSegmentAccessor {
 
         SegmentFillAccessor(int id, MemorySegment segment, Arena _unused) {
@@ -263,6 +289,7 @@ public class TestHandshake {
         return new Object[][] {
                 { "SegmentAccessor", (AccessorFactory)SegmentAccessor::new },
                 { "SegmentCopyAccessor", (AccessorFactory)SegmentCopyAccessor::new },
+                { "SegmentSwappyCopyAccessor", (AccessorFactory)SegmentSwappyCopyAccessor::new },
                 { "SegmentMismatchAccessor", (AccessorFactory)SegmentMismatchAccessor::new },
                 { "SegmentFillAccessor", (AccessorFactory)SegmentFillAccessor::new },
                 { "BufferAccessor", (AccessorFactory)BufferAccessor::new },


### PR DESCRIPTION
- Use `NoSafepointVerifier` to verify that we don't actually get a safepoint after checking for async exception handshake. Not every unsafe function is compatible with this, so I've introduced a new `UNSAFE_ENTRY_SCOPED` macro that can be used for unsafe functions called in the context of `@Scoped` methods (from ScopedMemoryAccess).

- `Unsafe_CopySwapMemory0` was actually polling for safepoint halfway into the function. This function tries to stay in the native thread state for off-heap -> off-heap copies, to avoid blocking the GC, and then lazily transitions to VM state when heap memory is involved. I've flipped this around so that we instead lazily transition to native state when we do a pure off-heap copy. I believe this is also required for safely checking for async exception handshakes, as we potentially take a lock for that, so should be in VM mode (I think?). Unfortunately, this means that we will now have 2 thread state transitions for the purely off-heap case: one from native to VM when the function is entered, and one from VM to native just before the copy. While unfortunate, I don't see a good way around this, as we need to check for async exception handshakes upon entering the method in case of any previous safepoint poll having installed a handshake. The additional state transitions could be avoided by intrinsifying the method, similar to how Unsafe_CopyMemory0 is already intrinsified.